### PR TITLE
Improve regexp used to parse labels

### DIFF
--- a/pygments_promql/__init__.py
+++ b/pygments_promql/__init__.py
@@ -167,7 +167,7 @@ class PromQLLexer(RegexLexer):
             (r"\s+", Whitespace),
             (r",", Punctuation),
             (
-                r'([_a-zA-Z][_a-zA-Z0-9]*?)(\s*?)(=|!=|=~|~!)(\s*?)(")(.*?)(")',
+                r"""([_a-zA-Z][_a-zA-Z0-9]*?)(\s*?)(=|!=|=~|~!)(\s*?)("|')(.*?)("|')""",
                 bygroups(
                     Name.Label,
                     Whitespace,

--- a/pygments_promql/__init__.py
+++ b/pygments_promql/__init__.py
@@ -167,7 +167,7 @@ class PromQLLexer(RegexLexer):
             (r"\s+", Whitespace),
             (r",", Punctuation),
             (
-                r"""([_a-zA-Z][_a-zA-Z0-9]*?)(\s*?)(=|!=|=~|~!)(\s*?)("|')(.*?)("|')""",
+                r"""([_a-zA-Z][_a-zA-Z0-9]*?)(\s*?)(=|!=|=~|!~)(\s*?)("|')(.*?)("|')""",
                 bygroups(
                     Name.Label,
                     Whitespace,

--- a/tests/test_promql.py
+++ b/tests/test_promql.py
@@ -308,3 +308,79 @@ def test_function_multi_line2(lexer):
         (Token.Text.Whitespace, "\n"),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_complex_exp_double_quotes(lexer):
+    fragment = u'(sum(rate(metric_test_app{app="turtle",proc="web"}[2m])) by(node))\n'
+    tokens = [
+        (Token.Operator, "("),
+        (Token.Keyword, "sum"),
+        (Token.Operator, "("),
+        (Token.Keyword.Reserved, "rate"),
+        (Token.Operator, "("),
+        (Token.Name.Variable, "metric_test_app"),
+        (Token.Punctuation, "{"),
+        (Token.Name.Label, "app"),
+        (Token.Operator, "="),
+        (Token.Punctuation, '"'),
+        (Token.Literal.String, "turtle"),
+        (Token.Punctuation, '"'),
+        (Token.Punctuation, ","),
+        (Token.Name.Label, "proc"),
+        (Token.Operator, "="),
+        (Token.Punctuation, '"'),
+        (Token.Literal.String, "web"),
+        (Token.Punctuation, '"'),
+        (Token.Punctuation, "}"),
+        (Token.Punctuation, "["),
+        (Token.Literal.String, "2m"),
+        (Token.Punctuation, "]"),
+        (Token.Operator, ")"),
+        (Token.Operator, ")"),
+        (Token.Text.Whitespace, " "),
+        (Token.Keyword, "by"),
+        (Token.Operator, "("),
+        (Token.Name.Variable, "node"),
+        (Token.Operator, ")"),
+        (Token.Operator, ")"),
+        (Token.Text.Whitespace, "\n"),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_complex_exp_single_quotes(lexer):
+    fragment = u"(sum(rate(metric_test_app{app='turtle',proc='web'}[2m])) by(node))\n"
+    tokens = [
+        (Token.Operator, "("),
+        (Token.Keyword, "sum"),
+        (Token.Operator, "("),
+        (Token.Keyword.Reserved, "rate"),
+        (Token.Operator, "("),
+        (Token.Name.Variable, "metric_test_app"),
+        (Token.Punctuation, "{"),
+        (Token.Name.Label, "app"),
+        (Token.Operator, "="),
+        (Token.Punctuation, "'"),
+        (Token.Literal.String, "turtle"),
+        (Token.Punctuation, "'"),
+        (Token.Punctuation, ","),
+        (Token.Name.Label, "proc"),
+        (Token.Operator, "="),
+        (Token.Punctuation, "'"),
+        (Token.Literal.String, "web"),
+        (Token.Punctuation, "'"),
+        (Token.Punctuation, "}"),
+        (Token.Punctuation, "["),
+        (Token.Literal.String, "2m"),
+        (Token.Punctuation, "]"),
+        (Token.Operator, ")"),
+        (Token.Operator, ")"),
+        (Token.Text.Whitespace, " "),
+        (Token.Keyword, "by"),
+        (Token.Operator, "("),
+        (Token.Name.Variable, "node"),
+        (Token.Operator, ")"),
+        (Token.Operator, ")"),
+        (Token.Text.Whitespace, "\n"),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_promql.py
+++ b/tests/test_promql.py
@@ -384,3 +384,22 @@ def test_complex_exp_single_quotes(lexer):
         (Token.Text.Whitespace, "\n"),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_matching_operator_no_regexmatch(lexer):
+    fragment = u"metric_test_app{status!~'(4|5)..'}[2m]"
+    tokens = [
+        (Token.Name.Variable, "metric_test_app"),
+        (Token.Punctuation, "{"),
+        (Token.Name.Label, "status"),
+        (Token.Operator, "!~"),
+        (Token.Punctuation, "'"),
+        (Token.Literal.String, "(4|5).."),
+        (Token.Punctuation, "'"),
+        (Token.Punctuation, "}"),
+        (Token.Punctuation, "["),
+        (Token.Literal.String, "2m"),
+        (Token.Punctuation, "]"),
+        (Token.Text.Whitespace, "\n"),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
This PR fixes #4. Labels were only detected when using double quotes, even if single quotes are totally valid. Now labels with single quotes are detected as well.

These 2 expressions must generate the same output, it wasn't the case before this PR:
```
(sum(rate(metric_test_app{app='turtle',proc='web'}[2m])) by(node))
```
```
(sum(rate(metric_test_app{app="turtle",proc="web"}[2m])) by(node))
```