### PR TITLE
requirements: bump pillow to 9.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flake8==3.8.3
-Pillow==9.0.0
+Pillow==9.0.1
 Pygments==2.7.4
 pytest==6.2.5


### PR DESCRIPTION
Mainly to address the following CVEs:
* CVE-2022-24303: If the path to the temporary directory
on Linux or macOS contained a space, this would break removal of
the temporary image file after im.show() (and related actions),
and potentially remove an unrelated file.
This been present since PIL.

* CVE-2022-22817: While Pillow 9.0 restricted top-level builtins
available to PIL.ImageMath.eval(), it did not prevent builtins
available to lambda expressions. These are now also restricted.

Signed-off-by: Mathieu Tortuyaux <mathieu.tortuyaux@gmail.com>