### PR TITLE
feat: add ability to parse promql with grafana templates inside

### DIFF
--- a/pygments_promql/__init__.py
+++ b/pygments_promql/__init__.py
@@ -157,7 +157,8 @@ class PromQLLexer(RegexLexer):
             (r"==|!=|>=|<=|<|>", Operator),
             (r"and|or|unless", Operator.Word),
             # Metrics
-            (r"[_a-zA-Z][_a-zA-Z0-9]+", Name.Variable),
+            (r"[_a-zA-Z][_a-zA-Z0-9]+(\$\{?[_a-zA-Z0-9]*\})?[_a-zA-Z0-9]*", Name.Variable),
+            # (r"[_a-zA-Z][_a-zA-Z0-9]+", Name.Variable),
             # Params
             (r'(["\'])(.*?)(["\'])', bygroups(Punctuation, String, Punctuation)),
             # Other states

--- a/tests/example_grafana_templated.promql
+++ b/tests/example_grafana_templated.promql
@@ -1,0 +1,10 @@
+# A metric with label filtering
+go_gc_duration_seconds{instance="localhost:9090", job="alertmanager"}
+
+# Aggregation operators
+sum by (app, proc) (
+  instance_memory_limit_bytes - instance_memory_usage_bytes
+) / 1024 / 1024
+
+# Grafana promql request with template
+vault_route_create_${mountpoint}_{quantile="0.99"}

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -18,6 +18,28 @@ def test_unknown_tokens():
     for token_type, value in lx.get_tokens(text):
         ntext.append(value)
         assert (
+                token_type != Error
+        ), "lexer %s generated error token: %r at position %d: %s" % (
+            lx,
+            value,
+            len(u"".join(ntext)),
+            u"".join(ntext),
+        )
+
+
+def test_local_promqllexer_unknown_tokens():
+    with open("tests/example_grafana_templated.promql") as f:
+        text = f.read()
+
+    import sys
+    sys.path.insert(1, './pygments-promql')
+    from pygments_promql import PromQLLexer
+    lx = PromQLLexer()
+
+    ntext = []
+    for token_type, value in lx.get_tokens(text):
+        ntext.append(value)
+        assert (
             token_type != Error
         ), "lexer %s generated error token: %r at position %d: %s" % (
             lx,


### PR DESCRIPTION
Hello!

I'm writing a script, which can download grafana dashboard, patch promql expressions (add some labels, rename labels, etc),
and push it back to grafana.

For parsing promql I'm using the lexer, and while doing some tests I faced the problem:
  at some dashboards promql expressions contain grafana templates.
  
  here is an example of the expression:
  `vault_route_create_${mountpoint}_{quantile="0.99"}`
  
  and it made a problem while parsing it, because the `Metrics` regex doesn't contain an expression to parse strings inside `${}` symbols.

So, the little fix adds the ability to parse promql expressions that contain grafana templates inside.

P.S. While making the changes I found that the tests is not using local `PromQLLexer` class, so I added a new test, which is testing the new changes, with new test cases.
