### PR TITLE
Bump flake8 and pytest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.8.3
+flake8==5.0.4
 Pillow==9.0.1
 Pygments==2.7.4
-pytest==6.2.5
+pytest==7.2.0


### PR DESCRIPTION
* flake8 from 3.8.3 to 5.0.4
* pytest from 6.2.5 to 7.2.0