### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "Topic :: Text Processing",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["Pygments>=2"],
     entry_points={
         "pygments.lexers": ["PromQLLexer = pygments_promql:PromQLLexer"],


### PR DESCRIPTION
In order to be compatible with pygments >= 2.20.0 this PR drops Python 3.8 support.

See https://pygments.org/docs/changelog/#version-2-20-0 for details.